### PR TITLE
Update `VameProject` to allow multiple series

### DIFF
--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -10,26 +10,34 @@ Version |release| |today|
 Data Structure Overview
 =======================
 
-This extension defines three main neurodata types:
+This extension defines four main neurodata types:
 
-1. **MotifSeries**: Extends ``TimeSeries`` to store VAME motif data. Each column in the data represents a different motif, and each row represents a time point.
+1. **LatentSpaceSeries**: Extends ``TimeSeries`` to store VAME latent space vectors over time.
 
-2. **CommunitySeries**: Extends ``TimeSeries`` to store VAME community data. Communities are groups of similar motifs. Each column in the data represents a different community, and each row represents a time point.
+2. **MotifSeries**: Extends ``TimeSeries`` to store VAME motif IDs over time. Optionally links to the ``LatentSpaceSeries`` used to generate it.
 
-3. **VAMEGroup**: A container for VAME data that includes both MotifSeries and CommunitySeries, and links to the original PoseEstimation data used to generate the VAME analysis.
+3. **CommunitySeries**: Extends ``TimeSeries`` to store VAME community IDs over time. Optionally links to the ``MotifSeries`` used to generate it.
+
+4. **VAMEProject**: A container for VAME data. Holds one optional ``LatentSpaceSeries``, zero or more ``MotifSeries``, and zero or more ``CommunitySeries``. Links to the original ``PoseEstimation`` data used as input.
 
 Relationship Diagram
 --------------------
 
 .. code-block:: text
 
-    VAMEGroup
-    ├── motif_series (MotifSeries)
-    ├── community_series (CommunitySeries)
-    │   └── motif_series (link to MotifSeries)
-    └── pose_estimation (link to PoseEstimation)
+    VAMEProject
+    ├── latent_space_series (LatentSpaceSeries, optional)
+    ├── MotifSeriesHmm (MotifSeries)
+    │   └── latent_space_series (link to LatentSpaceSeries, optional)
+    ├── MotifSeriesKmeans (MotifSeries)
+    │   └── latent_space_series (link to LatentSpaceSeries, optional)
+    ├── CommunitySeriesHmm (CommunitySeries)
+    │   └── motif_series (link to MotifSeries, optional)
+    ├── CommunitySeriesKmeans (CommunitySeries)
+    │   └── motif_series (link to MotifSeries, optional)
+    └── pose_estimation (link to PoseEstimation, optional)
 
-The VAMEGroup contains both the MotifSeries and CommunitySeries, and links to the PoseEstimation data that was used as input to VAME. The CommunitySeries also links to the MotifSeries to establish the relationship between motifs and communities.
+A ``VAMEProject`` can hold multiple ``MotifSeries`` and ``CommunitySeries`` (e.g. results from different algorithms). Each ``CommunitySeries`` optionally links back to the ``MotifSeries`` it was derived from.
 
 Detailed Specification
 ======================

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -19,13 +19,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "plaintext"
     }
    },
-   "outputs": [],
    "source": [
     "import datetime\n",
     "import numpy as np\n",
@@ -33,8 +31,15 @@
     "from pynwb import NWBFile, NWBHDF5IO\n",
     "from pynwb.file import Subject\n",
     "from ndx_pose import PoseEstimationSeries, PoseEstimation\n",
-    "from ndx_vame import VAMEProject, LatentSpaceSeries, MotifSeries, CommunitySeries"
-   ]
+    "from ndx_vame import (\n",
+    "    VAMEProject,\n",
+    "    LatentSpaceSeries,\n",
+    "    MotifSeries,\n",
+    "    CommunitySeries,\n",
+    ")"
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -45,9 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "# initialize an NWBFile object\n",
     "nwbfile = NWBFile(\n",
@@ -125,7 +128,9 @@
     "    description=\"processed behavioral data\",\n",
     ")\n",
     "behavior_pm.add(pose_estimation)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -134,40 +139,58 @@
     "Now we can include VAME-related data to the NWB file:\n",
     "\n",
     "- Latent space data\n",
-    "- Motifs data\n",
-    "- Communities data"
+    "- Motif data (one per algorithm)\n",
+    "- Community data (one per algorithm)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# VAME data\n",
-    "latent_data = np.random.rand(100, 30)  # (n_samples, z_dims)\n",
-    "data_motifs = np.random.randint(0, 15, size=100)  # (n_samples)\n",
-    "data_communities = np.random.randint(0, 3, size=100)  # (n_samples)\n",
+    "n_samples = 100\n",
+    "rate = 10.0\n",
     "\n",
+    "latent_data = np.random.rand(n_samples, 30)  # (n_samples, z_dims)\n",
     "latent_space_series = LatentSpaceSeries(\n",
     "    name=\"LatentSpaceSeries\",\n",
     "    data=latent_data,\n",
-    "    rate=10.,\n",
+    "    rate=rate,\n",
     ")\n",
     "\n",
-    "motif_series = MotifSeries(\n",
-    "    name=\"MotifSeries\",\n",
-    "    data=data_motifs,\n",
-    "    rate=10.,\n",
+    "# Create two MotifSeries using different algorithms\n",
+    "motif_series_hmm = MotifSeries(\n",
+    "    name=\"MotifSeriesHmm\",\n",
+    "    description=\"Motif labels from HMM clustering.\",\n",
+    "    data=np.random.randint(0, 15, size=n_samples, dtype=np.int32),\n",
+    "    rate=rate,\n",
     "    algorithm=\"hmm\",\n",
     "    latent_space_series=latent_space_series,\n",
     ")\n",
-    "community_series = CommunitySeries(\n",
-    "    name=\"CommunitySeries\",\n",
-    "    data=data_communities,\n",
-    "    rate=10.,\n",
+    "motif_series_kmeans = MotifSeries(\n",
+    "    name=\"MotifSeriesKmeans\",\n",
+    "    description=\"Motif labels from K-means clustering.\",\n",
+    "    data=np.random.randint(0, 15, size=n_samples, dtype=np.int32),\n",
+    "    rate=rate,\n",
+    "    algorithm=\"kmeans\",\n",
+    "    latent_space_series=latent_space_series,\n",
+    ")\n",
+    "\n",
+    "# Create two CommunitySeries, each linked to a MotifSeries\n",
+    "community_series_hmm = CommunitySeries(\n",
+    "    name=\"CommunitySeriesHmm\",\n",
+    "    description=\"Community labels from hierarchical clustering of HMM motifs.\",\n",
+    "    data=np.random.randint(0, 3, size=n_samples),\n",
+    "    rate=rate,\n",
     "    algorithm=\"hierarchical_clustering\",\n",
-    "    motif_series=motif_series,\n",
+    "    motif_series=motif_series_hmm,\n",
+    ")\n",
+    "community_series_kmeans = CommunitySeries(\n",
+    "    name=\"CommunitySeriesKmeans\",\n",
+    "    description=\"Community labels from graph clustering of K-means motifs.\",\n",
+    "    data=np.random.randint(0, 3, size=n_samples),\n",
+    "    rate=rate,\n",
+    "    algorithm=\"graph_clustering\",\n",
+    "    motif_series=motif_series_kmeans,\n",
     ")\n",
     "\n",
     "config_dict = {}  # Configuration dictionary from VAME project\n",
@@ -175,44 +198,29 @@
     "    name=\"VAMEProject\",\n",
     "    pose_estimation=pose_estimation,\n",
     "    latent_space_series=latent_space_series,\n",
-    "    motif_series=motif_series,\n",
-    "    community_series=community_series,\n",
+    "    motif_series=[motif_series_hmm, motif_series_kmeans],\n",
+    "    community_series=[community_series_hmm, community_series_kmeans],\n",
     "    vame_config=json.dumps(config_dict),\n",
     ")\n",
     "\n",
     "behavior_pm.add(vame_project)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
+   "source": "# write the NWBFile to disk\npath = \"test_vame.nwb\"\nwith NWBHDF5IO(path, mode=\"w\") as io:\n    io.write(nwbfile)\n\n# read the NWBFile from disk\nwith NWBHDF5IO(path, mode=\"r\") as io:\n    nwbfile_read = io.read()\n    vame_project_read = nwbfile_read.processing[\"behavior\"][\"VAMEProject\"]\n    print(vame_project_read)\n\n    print(\"\\nMotif series:\")\n    for name, ms in vame_project_read.motif_series.items():\n        print(f\"  {name}: algorithm={ms.algorithm}, description='{ms.description}', n_samples={len(ms.data[:])}\")\n\n    print(\"\\nCommunity series:\")\n    for name, cs in vame_project_read.community_series.items():\n        print(f\"  {name}: algorithm={cs.algorithm}, description='{cs.description}', n_samples={len(cs.data[:])}\")",
    "outputs": [],
-   "source": [
-    "# write the NWBFile to disk\n",
-    "path = \"test_vame.nwb\"\n",
-    "with NWBHDF5IO(path, mode=\"w\") as io:\n",
-    "    io.write(nwbfile)\n",
-    "\n",
-    "# read the NWBFile from disk\n",
-    "io = NWBHDF5IO(path, mode=\"r\")\n",
-    "nwbfile = io.read()\n",
-    "print(nwbfile.processing[\"behavior\"][\"VAMEProject\"])"
-   ]
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
+   "source": [],
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
+   "execution_count": null
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ndx-vame"
-version = "0.3.0"
+version = "0.3.1"
 authors = [{ name = "Luiz Tauffer", email = "luiz.tauffer@catalystneuro.com" }]
 description = "NWB extension for VAME"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ndx-vame"
-version = "0.2.2"
+version = "0.2.3"
 authors = [{ name = "Luiz Tauffer", email = "luiz.tauffer@catalystneuro.com" }]
 description = "NWB extension for VAME"
 readme = "README.md"

--- a/spec/ndx-vame.extensions.yaml
+++ b/spec/ndx-vame.extensions.yaml
@@ -60,15 +60,59 @@ groups:
     dtype: text
     doc: The VAME config, as a stringfied JSON.
   groups:
-  - neurodata_type_inc: LatentSpaceSeries
+  - neurodata_type_def: LatentSpaceSeries
+    neurodata_type_inc: TimeSeries
+    doc: An extension of TimeSeries to include VAME latent space data.
     quantity: '?'
-    doc: The latent space series for this VAME project.
-  - neurodata_type_inc: MotifSeries
+    datasets:
+    - name: data
+      dtype: float32
+      shape:
+      - null
+      - null
+      doc: Latent-space vectors over time.
+  - neurodata_type_def: MotifSeries
+    neurodata_type_inc: TimeSeries
+    doc: An extension of TimeSeries to include VAME motif data.
     quantity: '*'
-    doc: The motif series for this VAME project.
-  - neurodata_type_inc: CommunitySeries
+    attributes:
+    - name: algorithm
+      dtype: text
+      default_value: n/a
+      doc: The algorithm used for motif detection.
+      required: false
+    datasets:
+    - name: data
+      dtype: int32
+      shape:
+      - null
+      doc: Motif IDs over time.
+    links:
+    - name: latent_space_series
+      target_type: LatentSpaceSeries
+      doc: The latent space series associated with this motif series.
+      quantity: '?'
+  - neurodata_type_def: CommunitySeries
+    neurodata_type_inc: TimeSeries
+    doc: An extension of TimeSeries to include VAME community data.
     quantity: '*'
-    doc: The community series for this VAME project.
+    attributes:
+    - name: algorithm
+      dtype: text
+      default_value: n/a
+      doc: The algorithm used for community clustering.
+      required: false
+    datasets:
+    - name: data
+      dtype: int32
+      shape:
+      - null
+      doc: Community IDs over time.
+    links:
+    - name: motif_series
+      target_type: MotifSeries
+      doc: The motif series associated with this community series.
+      quantity: '?'
   links:
   - name: pose_estimation
     target_type: PoseEstimation

--- a/spec/ndx-vame.extensions.yaml
+++ b/spec/ndx-vame.extensions.yaml
@@ -60,59 +60,15 @@ groups:
     dtype: text
     doc: The VAME config, as a stringfied JSON.
   groups:
-  - neurodata_type_def: LatentSpaceSeries
-    neurodata_type_inc: TimeSeries
-    doc: An extension of TimeSeries to include VAME latent space data.
+  - neurodata_type_inc: LatentSpaceSeries
     quantity: '?'
-    datasets:
-    - name: data
-      dtype: float32
-      shape:
-      - null
-      - null
-      doc: Latent-space vectors over time.
-  - neurodata_type_def: MotifSeries
-    neurodata_type_inc: TimeSeries
-    doc: An extension of TimeSeries to include VAME motif data.
-    quantity: '?'
-    attributes:
-    - name: algorithm
-      dtype: text
-      default_value: n/a
-      doc: The algorithm used for motif detection.
-      required: false
-    datasets:
-    - name: data
-      dtype: int32
-      shape:
-      - null
-      doc: Motif IDs over time.
-    links:
-    - name: latent_space_series
-      target_type: LatentSpaceSeries
-      doc: The latent space series associated with this motif series.
-      quantity: '?'
-  - neurodata_type_def: CommunitySeries
-    neurodata_type_inc: TimeSeries
-    doc: An extension of TimeSeries to include VAME community data.
-    quantity: '?'
-    attributes:
-    - name: algorithm
-      dtype: text
-      default_value: n/a
-      doc: The algorithm used for community clustering.
-      required: false
-    datasets:
-    - name: data
-      dtype: int32
-      shape:
-      - null
-      doc: Community IDs over time.
-    links:
-    - name: motif_series
-      target_type: MotifSeries
-      doc: The motif series associated with this community series.
-      quantity: '?'
+    doc: The latent space series for this VAME project.
+  - neurodata_type_inc: MotifSeries
+    quantity: '*'
+    doc: The motif series for this VAME project.
+  - neurodata_type_inc: CommunitySeries
+    quantity: '*'
+    doc: The community series for this VAME project.
   links:
   - name: pose_estimation
     target_type: PoseEstimation

--- a/spec/ndx-vame.extensions.yaml
+++ b/spec/ndx-vame.extensions.yaml
@@ -60,59 +60,15 @@ groups:
     dtype: text
     doc: The VAME config, as a stringfied JSON.
   groups:
-  - neurodata_type_def: LatentSpaceSeries
-    neurodata_type_inc: TimeSeries
-    doc: An extension of TimeSeries to include VAME latent space data.
+  - neurodata_type_inc: LatentSpaceSeries
     quantity: '?'
-    datasets:
-    - name: data
-      dtype: float32
-      shape:
-      - null
-      - null
-      doc: Latent-space vectors over time.
-  - neurodata_type_def: MotifSeries
-    neurodata_type_inc: TimeSeries
-    doc: An extension of TimeSeries to include VAME motif data.
+    doc: The latent space series for this VAME project.
+  - neurodata_type_inc: MotifSeries
     quantity: '*'
-    attributes:
-    - name: algorithm
-      dtype: text
-      default_value: n/a
-      doc: The algorithm used for motif detection.
-      required: false
-    datasets:
-    - name: data
-      dtype: int32
-      shape:
-      - null
-      doc: Motif IDs over time.
-    links:
-    - name: latent_space_series
-      target_type: LatentSpaceSeries
-      doc: The latent space series associated with this motif series.
-      quantity: '?'
-  - neurodata_type_def: CommunitySeries
-    neurodata_type_inc: TimeSeries
-    doc: An extension of TimeSeries to include VAME community data.
+    doc: The motif series for this VAME project.
+  - neurodata_type_inc: CommunitySeries
     quantity: '*'
-    attributes:
-    - name: algorithm
-      dtype: text
-      default_value: n/a
-      doc: The algorithm used for community clustering.
-      required: false
-    datasets:
-    - name: data
-      dtype: int32
-      shape:
-      - null
-      doc: Community IDs over time.
-    links:
-    - name: motif_series
-      target_type: MotifSeries
-      doc: The motif series associated with this community series.
-      quantity: '?'
+    doc: The community series for this VAME project.
   links:
   - name: pose_estimation
     target_type: PoseEstimation

--- a/spec/ndx-vame.extensions.yaml
+++ b/spec/ndx-vame.extensions.yaml
@@ -78,13 +78,22 @@ groups:
   groups:
   - neurodata_type_inc: LatentSpaceSeries
     quantity: '?'
-    doc: The latent space series for this VAME project.
+    doc: An extension of TimeSeries to include VAME latent space data. Computed 
+      with a sliding window of time_window_samples, so it is shorter than the 
+      source pose/video and its timing should be offset by time_window_samples/2
+      relative to the pose or video.
   - neurodata_type_inc: MotifSeries
     quantity: '*'
-    doc: The motif series for this VAME project.
+    doc: An extension of TimeSeries to include VAME motif data. Computed with a 
+      sliding window of time_window_samples, so it is shorter than the source 
+      pose/video and its timing should be offset by time_window_samples/2 
+      relative to the pose or video.
   - neurodata_type_inc: CommunitySeries
     quantity: '*'
-    doc: The community series for this VAME project.
+    doc: An extension of TimeSeries to include VAME community data. Computed 
+      with a sliding window of time_window_samples, so it is shorter than the 
+      source pose/video and its timing should be offset by time_window_samples/2
+      relative to the pose or video.
   links:
   - name: pose_estimation
     target_type: PoseEstimation

--- a/spec/ndx-vame.extensions.yaml
+++ b/spec/ndx-vame.extensions.yaml
@@ -76,50 +76,6 @@ groups:
     dtype: text
     doc: Version of the VAME package used to produce this data.
   groups:
-  - neurodata_type_def: LatentSpaceSeries
-    neurodata_type_inc: TimeSeries
-    doc: An extension of TimeSeries to include VAME latent space data. Computed 
-      with a sliding window of time_window_samples, so it is shorter than the 
-      source pose/video and its timing should be offset by time_window_samples/2
-      relative to the pose or video.
-    quantity: '?'
-    datasets:
-    - name: data
-      dtype: float32
-      shape:
-      - null
-      - null
-      doc: Latent-space vectors over time.
-  - neurodata_type_def: MotifSeries
-    neurodata_type_inc: TimeSeries
-    doc: An extension of TimeSeries to include VAME motif data. Computed with a 
-      sliding window of time_window_samples, so it is shorter than the source 
-      pose/video and its timing should be offset by time_window_samples/2 
-      relative to the pose or video.
-    quantity: '?'
-    attributes:
-    - name: algorithm
-      dtype: text
-      default_value: n/a
-      doc: The algorithm used for motif detection.
-      required: false
-    datasets:
-    - name: data
-      dtype: int32
-      shape:
-      - null
-      doc: Motif IDs over time.
-    links:
-    - name: latent_space_series
-      target_type: LatentSpaceSeries
-      doc: The latent space series associated with this motif series.
-      quantity: '?'
-  - neurodata_type_def: CommunitySeries
-    neurodata_type_inc: TimeSeries
-    doc: An extension of TimeSeries to include VAME community data. Computed 
-      with a sliding window of time_window_samples, so it is shorter than the 
-      source pose/video and its timing should be offset by time_window_samples/2
-      relative to the pose or video.
   - neurodata_type_inc: LatentSpaceSeries
     quantity: '?'
     doc: The latent space series for this VAME project.

--- a/src/pynwb/tests/test_ndx_vame.py
+++ b/src/pynwb/tests/test_ndx_vame.py
@@ -90,7 +90,7 @@ def pose_estimation(nwbfile):
 
 
 class TestVAMESingleAlgorithm:
-    """Test the VAME extension classes"""
+    """Test the VAME extension classes."""
 
     def test_roundtrip(self, nwbfile, pose_estimation):
         """Test writing and reading VAME data to and from an NWB file."""

--- a/src/pynwb/tests/test_ndx_vame.py
+++ b/src/pynwb/tests/test_ndx_vame.py
@@ -250,6 +250,8 @@ class TestVAMESingleAlgorithm:
                 motif_series=[motif_series_hmm, motif_series_kmeans],
                 community_series=[community_series_hmm, community_series_kmeans],
                 vame_config=vame_config,
+                time_window_samples=30,
+                vame_version="0.11.0",
             )
 
             behavior_pm.add(vame_project)

--- a/src/pynwb/tests/test_ndx_vame.py
+++ b/src/pynwb/tests/test_ndx_vame.py
@@ -89,8 +89,8 @@ def pose_estimation(nwbfile):
     return pose_estimation
 
 
-class TestVAME:
-    """Test the VAME extension classes."""
+class TestVAMESingleAlgorithm:
+    """Test the VAME extension classes"""
 
     def test_roundtrip(self, nwbfile, pose_estimation):
         """Test writing and reading VAME data to and from an NWB file."""
@@ -146,8 +146,8 @@ class TestVAME:
         vame_project = VAMEProject(
             name="VAMEProject",
             latent_space_series=latent_space_series,
-            motif_series=motif_series,
-            community_series=community_series,
+            motif_series=[motif_series],
+            community_series=[community_series],
             vame_config=vame_config,
             pose_estimation=pose_estimation,
         )
@@ -171,12 +171,12 @@ class TestVAME:
                 read_vame_project = nwbfile.processing["behavior"].data_interfaces["VAMEProject"]
                 assert read_vame_project.name == "VAMEProject"
 
-                read_motif_series = read_vame_project.motif_series
+                read_motif_series = read_vame_project.motif_series["MotifSeries"]
                 assert read_motif_series.name == "MotifSeries"
                 assert np.array_equal(read_motif_series.data[:], motif_data)
                 assert read_motif_series.rate == 10.0
 
-                read_community_series = read_vame_project.community_series
+                read_community_series = read_vame_project.community_series["CommunitySeries"]
                 assert read_community_series.name == "CommunitySeries"
                 assert np.array_equal(read_community_series.data[:], community_data)
                 assert read_community_series.rate == 10.0
@@ -186,3 +186,104 @@ class TestVAME:
             # Clean up the temporary file
             if os.path.exists(temp_file):
                 os.remove(temp_file)
+
+    class TestVAMEMultipleAlgorithms:
+        """Test that a VAMEProject can hold multiple MotifSeries and CommunitySeries."""
+
+        def test_roundtrip(self, nwbfile, pose_estimation):
+            behavior_pm = nwbfile.create_processing_module(
+                name="behavior",
+                description="processed behavioral data",
+            )
+            behavior_pm.add(pose_estimation)
+
+            n_samples = 50
+            rate = 10.0
+            latent_space_series = LatentSpaceSeries(
+                name="LatentSpaceSeries",
+                data=np.random.rand(n_samples, 10),
+                rate=rate,
+            )
+
+            motif_data_hmm = np.random.randint(0, 10, size=n_samples)
+            motif_series_hmm = MotifSeries(
+                name="MotifSeriesHmm",
+                data=motif_data_hmm,
+                rate=rate,
+                algorithm="hmm",
+            )
+
+            motif_data_kmeans = np.random.randint(0, 10, size=n_samples)
+            motif_series_kmeans = MotifSeries(
+                name="MotifSeriesKmeans",
+                data=motif_data_kmeans,
+                rate=rate,
+                algorithm="kmeans",
+            )
+
+            community_data = np.random.randint(0, 3, size=n_samples)
+            community_series_hmm = CommunitySeries(
+            name="CommunitySeriesHmm",
+            data=community_data,
+            rate=rate,
+            algorithm="hierarchical_clustering",
+            motif_series=motif_series_hmm,
+            )
+
+            community_data_kmeans = np.random.randint(0, 3, size=n_samples)
+            community_series_kmeans = CommunitySeries(
+                name="CommunitySeriesKmeans",
+                data=community_data_kmeans,
+                rate=rate,
+                algorithm="graph_clustering",
+                motif_series=motif_series_kmeans,
+            )
+
+            vame_config = json.dumps({"vame_version": "0.11.0", "project_name": "multi_series_project"})
+            vame_project = VAMEProject(
+                name="VAMEProject",
+                latent_space_series=latent_space_series,
+                motif_series=[motif_series_hmm, motif_series_kmeans],
+                community_series=[community_series_hmm, community_series_kmeans],
+                vame_config=vame_config,
+            )
+
+            behavior_pm.add(vame_project)
+
+            # Verify in-memory before roundtrip
+            assert len(vame_project.motif_series) == 2
+            assert "MotifSeriesHmm" in vame_project.motif_series
+            assert "MotifSeriesKmeans" in vame_project.motif_series
+            assert len(vame_project.community_series) == 2
+            assert "CommunitySeriesHmm" in vame_project.community_series
+            assert "CommunitySeriesKmeans" in vame_project.community_series
+
+            temp_file = os.path.join(tempfile.gettempdir(), "test_vame_multi.nwb")
+            try:
+                with NWBHDF5IO(temp_file, "w") as io:
+                    io.write(nwbfile)
+
+                with NWBHDF5IO(temp_file, "r") as io:
+                    read_nwbfile = io.read()
+                    read_vame_project = read_nwbfile.processing["behavior"].data_interfaces["VAMEProject"]
+
+                    assert len(read_vame_project.motif_series) == 2
+                    read_hmm = read_vame_project.motif_series["MotifSeriesHmm"]
+                    assert np.array_equal(read_hmm.data[:], motif_data_hmm)
+                    assert read_hmm.algorithm == "hmm"
+
+                    read_kmeans = read_vame_project.motif_series["MotifSeriesKmeans"]
+                    assert np.array_equal(read_kmeans.data[:], motif_data_kmeans)
+                    assert read_kmeans.algorithm == "kmeans"
+
+                    assert len(read_vame_project.community_series) == 2
+                    read_hmm = read_vame_project.community_series["CommunitySeriesHmm"]
+                    assert np.array_equal(read_hmm.data[:], community_data)
+                    assert read_hmm.algorithm == "hierarchical_clustering"
+
+                    read_kmeans = read_vame_project.community_series["CommunitySeriesKmeans"]
+                    assert np.array_equal(read_kmeans.data[:], community_data_kmeans)
+                    assert read_kmeans.algorithm == "graph_clustering"
+            finally:
+                if os.path.exists(temp_file):
+                    os.remove(temp_file)

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -110,9 +110,15 @@ def main():
             ),
         ],
         groups=[
-            NWBGroupSpec(neurodata_type_inc="LatentSpaceSeries", quantity="?", doc="The latent space series for this VAME project."),
-            NWBGroupSpec(neurodata_type_inc="MotifSeries", quantity="*", doc="The motif series for this VAME project."),
-            NWBGroupSpec(neurodata_type_inc="CommunitySeries", quantity="*", doc="The community series for this VAME project."),
+            NWBGroupSpec(
+                neurodata_type_inc="LatentSpaceSeries", quantity="?", doc="The latent space series for this VAME project."
+            ),
+            NWBGroupSpec(
+                neurodata_type_inc="MotifSeries", quantity="*", doc="The motif series for this VAME project."
+            ),
+            NWBGroupSpec(
+                neurodata_type_inc="CommunitySeries", quantity="*", doc="The community series for this VAME project."
+            ),
         ],
         links=[
             NWBLinkSpec(

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -111,7 +111,9 @@ def main():
         ],
         groups=[
             NWBGroupSpec(
-                neurodata_type_inc="LatentSpaceSeries", quantity="?", doc="The latent space series for this VAME project."
+                neurodata_type_inc="LatentSpaceSeries",
+                quantity="?",
+                doc="The latent space series for this VAME project.",
             ),
             NWBGroupSpec(
                 neurodata_type_inc="MotifSeries", quantity="*", doc="The motif series for this VAME project."

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -110,9 +110,9 @@ def main():
             ),
         ],
         groups=[
-            latent_space_series,
-            motif_series,
-            community_series,
+            NWBGroupSpec(neurodata_type_inc="LatentSpaceSeries", quantity="?", doc="The latent space series for this VAME project."),
+            NWBGroupSpec(neurodata_type_inc="MotifSeries", quantity="*", doc="The motif series for this VAME project."),
+            NWBGroupSpec(neurodata_type_inc="CommunitySeries", quantity="*", doc="The community series for this VAME project."),
         ],
         links=[
             NWBLinkSpec(


### PR DESCRIPTION
Update ``VAMEProject`` to hold multiple ``MotifSeries`` and ``CommunitySeries`` (e.g. results from different algorithms). Each ``CommunitySeries`` optionally links back to the ``MotifSeries`` it was derived from.