### PR TITLE
 Document the VAME window offset and store `time_window_samples` / version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ cython_debug/
 # Other
 .virtual_documents/
 .vscode/
+uv.lock

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -178,6 +178,8 @@
     "    motif_series=motif_series,\n",
     "    community_series=community_series,\n",
     "    vame_config=json.dumps(config_dict),\n",
+    "    time_window_samples=30,\n",
+    "    vame_version=\"0.11.0\",\n",
     ")\n",
     "\n",
     "behavior_pm.add(vame_project)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ndx-vame"
-version = "0.2.2"
+version = "0.3.0"
 authors = [{ name = "Luiz Tauffer", email = "luiz.tauffer@catalystneuro.com" }]
 description = "NWB extension for VAME"
 readme = "README.md"

--- a/spec/ndx-vame.extensions.yaml
+++ b/spec/ndx-vame.extensions.yaml
@@ -1,7 +1,10 @@
 groups:
 - neurodata_type_def: LatentSpaceSeries
   neurodata_type_inc: TimeSeries
-  doc: An extension of TimeSeries to include VAME latent space data.
+  doc: An extension of TimeSeries to include VAME latent space data. Computed 
+    with a sliding window of time_window_samples, so it is shorter than the 
+    source pose/video and its timing should be offset by time_window_samples/2 
+    relative to the pose or video.
   quantity: '?'
   datasets:
   - name: data
@@ -12,7 +15,10 @@ groups:
     doc: Latent-space vectors over time.
 - neurodata_type_def: MotifSeries
   neurodata_type_inc: TimeSeries
-  doc: An extension of TimeSeries to include VAME motif data.
+  doc: An extension of TimeSeries to include VAME motif data. Computed with a 
+    sliding window of time_window_samples, so it is shorter than the source 
+    pose/video and its timing should be offset by time_window_samples/2 relative
+    to the pose or video.
   quantity: '?'
   attributes:
   - name: algorithm
@@ -33,7 +39,10 @@ groups:
     quantity: '?'
 - neurodata_type_def: CommunitySeries
   neurodata_type_inc: TimeSeries
-  doc: An extension of TimeSeries to include VAME community data.
+  doc: An extension of TimeSeries to include VAME community data. Computed with 
+    a sliding window of time_window_samples, so it is shorter than the source 
+    pose/video and its timing should be offset by time_window_samples/2 relative
+    to the pose or video.
   quantity: '?'
   attributes:
   - name: algorithm
@@ -59,10 +68,20 @@ groups:
   - name: vame_config
     dtype: text
     doc: The VAME config, as a stringfied JSON.
+  - name: time_window_samples
+    dtype: int32
+    doc: "VAME's time_window parameter: the number of samples in each sliding window
+      (the window of source samples each value summarizes)."
+  - name: vame_version
+    dtype: text
+    doc: Version of the VAME package used to produce this data.
   groups:
   - neurodata_type_def: LatentSpaceSeries
     neurodata_type_inc: TimeSeries
-    doc: An extension of TimeSeries to include VAME latent space data.
+    doc: An extension of TimeSeries to include VAME latent space data. Computed 
+      with a sliding window of time_window_samples, so it is shorter than the 
+      source pose/video and its timing should be offset by time_window_samples/2
+      relative to the pose or video.
     quantity: '?'
     datasets:
     - name: data
@@ -73,7 +92,10 @@ groups:
       doc: Latent-space vectors over time.
   - neurodata_type_def: MotifSeries
     neurodata_type_inc: TimeSeries
-    doc: An extension of TimeSeries to include VAME motif data.
+    doc: An extension of TimeSeries to include VAME motif data. Computed with a 
+      sliding window of time_window_samples, so it is shorter than the source 
+      pose/video and its timing should be offset by time_window_samples/2 
+      relative to the pose or video.
     quantity: '?'
     attributes:
     - name: algorithm
@@ -94,7 +116,10 @@ groups:
       quantity: '?'
   - neurodata_type_def: CommunitySeries
     neurodata_type_inc: TimeSeries
-    doc: An extension of TimeSeries to include VAME community data.
+    doc: An extension of TimeSeries to include VAME community data. Computed 
+      with a sliding window of time_window_samples, so it is shorter than the 
+      source pose/video and its timing should be offset by time_window_samples/2
+      relative to the pose or video.
     quantity: '?'
     attributes:
     - name: algorithm

--- a/spec/ndx-vame.namespace.yaml
+++ b/spec/ndx-vame.namespace.yaml
@@ -11,4 +11,4 @@ namespaces:
     neurodata_types:
     - PoseEstimation
   - source: ndx-vame.extensions.yaml
-  version: 0.2.2
+  version: 0.3.0

--- a/src/pynwb/tests/test_ndx_vame.py
+++ b/src/pynwb/tests/test_ndx_vame.py
@@ -149,6 +149,8 @@ class TestVAME:
             motif_series=motif_series,
             community_series=community_series,
             vame_config=vame_config,
+            time_window_samples=30,
+            vame_version="0.11.0",
             pose_estimation=pose_estimation,
         )
 
@@ -182,6 +184,8 @@ class TestVAME:
                 assert read_community_series.rate == 10.0
 
                 assert read_vame_project.vame_config == vame_config
+                assert read_vame_project.time_window_samples == 30
+                assert read_vame_project.vame_version == "0.11.0"
         finally:
             # Clean up the temporary file
             if os.path.exists(temp_file):

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -24,7 +24,7 @@ def make_dataset(dtype: str, doc: str, shape: tuple) -> NWBDatasetSpec:
 def main():
     ns_builder = NWBNamespaceBuilder(
         name="ndx-vame",
-        version="0.2.2",
+        version="0.3.0",
         doc="NWB extension for VAME",
         author=[
             "Luiz Tauffer",
@@ -42,7 +42,11 @@ def main():
     latent_space_series = NWBGroupSpec(
         neurodata_type_def="LatentSpaceSeries",
         neurodata_type_inc="TimeSeries",
-        doc="An extension of TimeSeries to include VAME latent space data.",
+        doc=(
+            "An extension of TimeSeries to include VAME latent space data. "
+            "Computed with a sliding window of time_window_samples, so it is shorter than the source "
+            "pose/video and its timing should be offset by time_window_samples/2 relative to the pose or video."
+        ),
         quantity="?",
         datasets=[make_dataset("float32", "Latent-space vectors over time.", shape=(None, None))],
     )
@@ -50,7 +54,11 @@ def main():
     motif_series = NWBGroupSpec(
         neurodata_type_def="MotifSeries",
         neurodata_type_inc="TimeSeries",
-        doc="An extension of TimeSeries to include VAME motif data.",
+        doc=(
+            "An extension of TimeSeries to include VAME motif data. "
+            "Computed with a sliding window of time_window_samples, so it is shorter than the source "
+            "pose/video and its timing should be offset by time_window_samples/2 relative to the pose or video."
+        ),
         quantity="?",
         datasets=[make_dataset("int32", "Motif IDs over time.", shape=(None,))],
         attributes=[
@@ -75,7 +83,11 @@ def main():
     community_series = NWBGroupSpec(
         neurodata_type_def="CommunitySeries",
         neurodata_type_inc="TimeSeries",
-        doc="An extension of TimeSeries to include VAME community data.",
+        doc=(
+            "An extension of TimeSeries to include VAME community data. "
+            "Computed with a sliding window of time_window_samples, so it is shorter than the source "
+            "pose/video and its timing should be offset by time_window_samples/2 relative to the pose or video."
+        ),
         quantity="?",
         datasets=[make_dataset("int32", "Community IDs over time.", shape=(None,))],
         attributes=[
@@ -105,6 +117,21 @@ def main():
             NWBAttributeSpec(
                 name="vame_config",
                 doc="The VAME config, as a stringfied JSON.",
+                dtype="text",
+                required=True,
+            ),
+            NWBAttributeSpec(
+                name="time_window_samples",
+                doc=(
+                    "VAME's time_window parameter: the number of samples in each sliding window "
+                    "(the window of source samples each value summarizes)."
+                ),
+                dtype="int32",
+                required=True,
+            ),
+            NWBAttributeSpec(
+                name="vame_version",
+                doc="Version of the VAME package used to produce this data.",
                 dtype="text",
                 required=True,
             ),


### PR DESCRIPTION
VAME computes its outputs (e.g. `LatentSpaceSeries`) with a sliding window of `time_window` samples moved one sample at a time. As a consequence, the series are shorter than the source pose/video and each value summarizes a whole window rather than a single sample (you can find it here [pose_segmentation.py#L117-L119](https://github.com/EthoML/VAME/blob/c68608b8c2bc217d64ccfe308a21696dc864fe4b/src/vame/analysis/pose_segmentation.py#L117-L119); even if it is not the default path). For NWB, where time alignment is necessary, the VAME exporter selects the middle sample of the windows as the alignment. That is, an offset of `time_window/2` relative to the source ([io/nwb.py#L122-L140](https://github.com/EthoML/VAME/blob/c68608b8c2bc217d64ccfe308a21696dc864fe4b/src/vame/io/nwb.py#L122-L140)). I think this is a sensible default because the window is symmetric and the encoder is bidirectional, so it has no temporal bias toward either end. 

This PR comes from neuroconv PR https://github.com/catalystneuro/neuroconv/pull/1737 and basically just documents that offset in the series docstrings so any writer applies it.

Working through this, I noticed some parameters are missing for full provenance. The one relevant here is the window size: it currently lives only inside the `vame_config` JSON string, so it is not discoverable, even though it is needed to interpret the timing and window extent of every series. This PR promotes it to a `time_window_samples` attribute on `VAMEProject`. I am also adding `vame_version`, which is important for checking which parameters and behavior should be available at a given release.
